### PR TITLE
Evan Week4 Misson 19.0.0 (refactoring of requesting of user data)

### DIFF
--- a/app/src/main/java/com/survivalcoding/network_apps/feature_paging/data/datasource/network/PostPagingDataSource.kt
+++ b/app/src/main/java/com/survivalcoding/network_apps/feature_paging/data/datasource/network/PostPagingDataSource.kt
@@ -13,7 +13,7 @@ class PostPagingDataSource(
     private val pagSize: Int = 20
 ) : PagingSource<Int, Post>() {
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, Post> {
-        return LoadResult.Error(Exception("error"))
+       // return LoadResult.Error(Exception("error------"))
         val nextPageNumber = params.key ?: 1
         return try {
             val response = service.getPosts(nextPageNumber, pagSize)

--- a/app/src/main/java/com/survivalcoding/network_apps/feature_paging/data/repositoryimpl/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/survivalcoding/network_apps/feature_paging/data/repositoryimpl/UserRepositoryImpl.kt
@@ -11,6 +11,10 @@ class UserRepositoryImpl(private val userDataSource: UserDataSource) : UserRepos
 
     override val users: MutableMap<Int, User?> = mutableMapOf()
 
+    override fun userRequestSet(id: Int) {
+        users[id] = User(null, null, null)
+    }
+
     // 임시로 에러 처리 전부 흡수
     override suspend fun getUserFromNet(id: Int): User? = try {
         userDataSource.getUser(id)?.let {

--- a/app/src/main/java/com/survivalcoding/network_apps/feature_paging/data/repositoryimpl/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/survivalcoding/network_apps/feature_paging/data/repositoryimpl/UserRepositoryImpl.kt
@@ -4,12 +4,24 @@ import com.survivalcoding.network_apps.feature_paging.data.UserMapper
 import com.survivalcoding.network_apps.feature_paging.data.datasource.network.UserDataSource
 import com.survivalcoding.network_apps.feature_paging.domain.model.User
 import com.survivalcoding.network_apps.feature_paging.domain.repository.UserRepository
+import java.lang.Exception
+import java.security.spec.ECField
 
 class UserRepositoryImpl(private val userDataSource: UserDataSource) : UserRepository {
 
-    override suspend fun getUserFromNet(id: Int): User? = userDataSource.getUser(id)?.let {
-        UserMapper.toModel(it)
+    override val users: MutableMap<Int, User?> = mutableMapOf()
+
+    // 임시로 에러 처리 전부 흡수
+    override suspend fun getUserFromNet(id: Int): User? = try {
+        userDataSource.getUser(id)?.let {
+            val model = UserMapper.toModel(it)
+            users[id] = model
+            model
+        }
+    } catch (e: Exception) {
+        null
     }
 
+    override fun getUserFromCache(id: Int): User? = users[id]
 
 }

--- a/app/src/main/java/com/survivalcoding/network_apps/feature_paging/domain/repository/UserRepository.kt
+++ b/app/src/main/java/com/survivalcoding/network_apps/feature_paging/domain/repository/UserRepository.kt
@@ -3,5 +3,7 @@ package com.survivalcoding.network_apps.feature_paging.domain.repository
 import com.survivalcoding.network_apps.feature_paging.domain.model.User
 
 interface UserRepository {
+    val users: MutableMap<Int, User?>
     suspend fun getUserFromNet(id: Int): User?
+    fun getUserFromCache(id: Int): User?
 }

--- a/app/src/main/java/com/survivalcoding/network_apps/feature_paging/domain/repository/UserRepository.kt
+++ b/app/src/main/java/com/survivalcoding/network_apps/feature_paging/domain/repository/UserRepository.kt
@@ -4,6 +4,7 @@ import com.survivalcoding.network_apps.feature_paging.domain.model.User
 
 interface UserRepository {
     val users: MutableMap<Int, User?>
+    fun userRequestSet(id: Int)
     suspend fun getUserFromNet(id: Int): User?
     fun getUserFromCache(id: Int): User?
 }

--- a/app/src/main/java/com/survivalcoding/network_apps/feature_paging/presentation/PagingFragment.kt
+++ b/app/src/main/java/com/survivalcoding/network_apps/feature_paging/presentation/PagingFragment.kt
@@ -11,7 +11,6 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.paging.LoadState
-import androidx.paging.PagingData
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.snackbar.Snackbar
@@ -34,12 +33,7 @@ class PagingFragment : Fragment(R.layout.fragment_paging) {
             (requireActivity().application as MyApp).userRepository
         )
     }
-    private val adapter = PostInfoListAdapter(
-        userFromCache = { id -> viewModel.getUserFromCache(id) },
-        userFromNet = { id ->
-            viewModel.eventHandler(TestEvent.RequestNet(id))
-        }
-    )
+    private val adapter = PostInfoListAdapter()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -65,27 +59,14 @@ class PagingFragment : Fragment(R.layout.fragment_paging) {
             repeatOnLifecycle(Lifecycle.State.RESUMED) {
                 adapter.addLoadStateListener {
                     if (it.refresh is LoadState.Error) {
-                        println((it.refresh as LoadState.Error).error.message)
                         Snackbar.make(view, "ERROR!!!", Snackbar.LENGTH_SHORT).show()
                     }
                 }
 
-                viewModel.state.collectLatest {
-                    it.post?.collectLatest { posts ->
-                        adapter.submitData(PagingData.empty())
-                        println(it.users)
-                        adapter.submitData(posts)
-                    }
-
+                viewModel.items.collectLatest {
+                    adapter.submitData(it)
                 }
 
-/*                viewModel.state.post?.collectLatest { pagingData ->
-                    adapter.submitData(pagingData)
-                }
-
-                viewModel. {
-                    adapter.submitData()
-                }*/
             }
         }
     }

--- a/app/src/main/java/com/survivalcoding/network_apps/feature_paging/presentation/PostInfoViewModel.kt
+++ b/app/src/main/java/com/survivalcoding/network_apps/feature_paging/presentation/PostInfoViewModel.kt
@@ -34,9 +34,8 @@ class PostInfoViewModel(
                             PostWithUserInfo(post = post, user = userInfo)
                         } else {
                             // network 연결이 필요한 경우
-                            userRepository.users[post.userId] = User(null, null, null)
+                            userRepository.userRequestSet(post.userId)
                             val newUser = userRepository.getUserFromNet(post.userId)
-                            userRepository.users[post.userId] = newUser
                             PostWithUserInfo(post = post, user = newUser)
                         }
                     }
@@ -48,8 +47,5 @@ class PostInfoViewModel(
 
 }
 
-data class PostWithUserInfo(
-    val post: Post,
-    val user: User?
-)
+
 

--- a/app/src/main/java/com/survivalcoding/network_apps/feature_paging/presentation/PostInfoViewModel.kt
+++ b/app/src/main/java/com/survivalcoding/network_apps/feature_paging/presentation/PostInfoViewModel.kt
@@ -2,7 +2,9 @@ package com.survivalcoding.network_apps.feature_paging.presentation
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.paging.PagingData
 import androidx.paging.cachedIn
+import androidx.paging.map
 import com.survivalcoding.network_apps.feature_paging.domain.model.Post
 import com.survivalcoding.network_apps.feature_paging.domain.model.User
 import com.survivalcoding.network_apps.feature_paging.domain.repository.PostRepository
@@ -17,65 +19,37 @@ class PostInfoViewModel(
     private val userRepository: UserRepository
 ) : ViewModel() {
 
-    private var _state =
-        MutableStateFlow(PostInfoState(post = postRepository.getPosts().cachedIn(viewModelScope)))
-    val state: Flow<PostInfoState> = _state
+    private var _items = MutableStateFlow<PagingData<PostWithUserInfo>>(PagingData.empty())
+    val items get(): Flow<PagingData<PostWithUserInfo>> = _items
 
-    private val requestProcess = mutableMapOf<Int, Int>()
-/*    init {
-       viewModelScope.launch {
-           postRepository.getPosts().cachedIn(viewModelScope).collect {
-               it.
-           }
-       }
-    }*/
-
-    // requesting = 1, // success = 2 // fail =3
-    private fun getUserFromNet(id: Int) {
-        if (requestProcess[id] == null) {
-            requestProcess[id] = 1
-            viewModelScope.launch {
-                val newUserInfo = userRepository.getUserFromNet(id)
-                newUserInfo?.id?.let { it ->
-                    requestProcess[id] = 2
-                    // _state.value.users[it] = newUserInfo
-                    val m = mutableMapOf<Int, User>()
-                    _state.value.users.toMap(m)
-                    m[it] = newUserInfo
-                    _state.value = _state.value.copy(users = m)
+    init {
+        viewModelScope.launch {
+            postRepository.getPosts().cachedIn(viewModelScope).collect {
+                _items.value = it.map { post ->
+                    if (post.userId == null) {
+                        PostWithUserInfo(post = post, user = null) // userID가 없을 경우
+                    } else {
+                        val userInfo = userRepository.getUserFromCache(post.userId) // cache 확인
+                        if (userInfo != null) {
+                            PostWithUserInfo(post = post, user = userInfo)
+                        } else {
+                            // network 연결이 필요한 경우
+                            userRepository.users[post.userId] = User(null, null, null)
+                            val newUser = userRepository.getUserFromNet(post.userId)
+                            userRepository.users[post.userId] = newUser
+                            PostWithUserInfo(post = post, user = newUser)
+                        }
+                    }
                 }
-                println(newUserInfo)
             }
         }
-
     }
 
-    fun getUserFromCache(id: Int): User? = _state.value.users[id]
-
-    fun eventHandler(event: TestEvent) {
-        when (event) {
-            is TestEvent.RequestCache -> {
-                getUserFromCache(event.id)
-            }
-            is TestEvent.RequestNet -> {
-                getUserFromNet(event.id)
-            }
-            is TestEvent.ResultNet -> {
-
-            }
-
-        }
-    }
 
 }
 
 data class PostWithUserInfo(
-    private val post: Post,
-    private val user: User
+    val post: Post,
+    val user: User?
 )
 
-sealed class TestEvent {
-    class RequestCache(val id: Int) : TestEvent()
-    class RequestNet(val id: Int) : TestEvent()
-    class ResultNet : TestEvent()
-}

--- a/app/src/main/java/com/survivalcoding/network_apps/feature_paging/presentation/PostInfoViewModel.kt
+++ b/app/src/main/java/com/survivalcoding/network_apps/feature_paging/presentation/PostInfoViewModel.kt
@@ -21,6 +21,7 @@ class PostInfoViewModel(
         MutableStateFlow(PostInfoState(post = postRepository.getPosts().cachedIn(viewModelScope)))
     val state: Flow<PostInfoState> = _state
 
+    private val requestProcess = mutableMapOf<Int, Int>()
 /*    init {
        viewModelScope.launch {
            postRepository.getPosts().cachedIn(viewModelScope).collect {
@@ -29,14 +30,24 @@ class PostInfoViewModel(
        }
     }*/
 
+    // requesting = 1, // success = 2 // fail =3
     private fun getUserFromNet(id: Int) {
-        viewModelScope.launch {
-            val newUserInfo = userRepository.getUserFromNet(id)
-            newUserInfo?.id?.let { it ->
-                _state.value.users[it] = newUserInfo
+        if (requestProcess[id] == null) {
+            requestProcess[id] = 1
+            viewModelScope.launch {
+                val newUserInfo = userRepository.getUserFromNet(id)
+                newUserInfo?.id?.let { it ->
+                    requestProcess[id] = 2
+                    // _state.value.users[it] = newUserInfo
+                    val m = mutableMapOf<Int, User>()
+                    _state.value.users.toMap(m)
+                    m[it] = newUserInfo
+                    _state.value = _state.value.copy(users = m)
+                }
+                println(newUserInfo)
             }
-            println(newUserInfo)
         }
+
     }
 
     fun getUserFromCache(id: Int): User? = _state.value.users[id]

--- a/app/src/main/java/com/survivalcoding/network_apps/feature_paging/presentation/PostWithUserInfo.kt
+++ b/app/src/main/java/com/survivalcoding/network_apps/feature_paging/presentation/PostWithUserInfo.kt
@@ -1,0 +1,9 @@
+package com.survivalcoding.network_apps.feature_paging.presentation
+
+import com.survivalcoding.network_apps.feature_paging.domain.model.Post
+import com.survivalcoding.network_apps.feature_paging.domain.model.User
+
+data class PostWithUserInfo(
+    val post: Post,
+    val user: User?
+)

--- a/app/src/main/java/com/survivalcoding/network_apps/feature_paging/presentation/adapter/PostInfoDiffItemCallback.kt
+++ b/app/src/main/java/com/survivalcoding/network_apps/feature_paging/presentation/adapter/PostInfoDiffItemCallback.kt
@@ -2,21 +2,14 @@ package com.survivalcoding.network_apps.feature_paging.presentation.adapter
 
 import androidx.recyclerview.widget.DiffUtil
 import com.survivalcoding.network_apps.feature_paging.domain.model.Post
+import com.survivalcoding.network_apps.feature_paging.presentation.PostWithUserInfo
 
-/*
-Note that DiffUtil, ListAdapter, and AsyncListDiffer require the list to not mutate while in use.
- This generally means that both the lists themselves and their elements
- (or at least, the properties of elements used in diffing) should not be modified directly.
- Instead, new lists should be provided any time content changes.
- It's common for lists passed to DiffUtil to share elements that have not mutated,
- so it is not strictly required to reload all data to use DiffUtil.
-* */
-object PostInfoDiffItemCallback : DiffUtil.ItemCallback<Post>() {
-    override fun areItemsTheSame(oldItem: Post, newItem: Post): Boolean {
-        return oldItem.id == newItem.id
+object PostInfoDiffItemCallback : DiffUtil.ItemCallback<PostWithUserInfo>() {
+    override fun areItemsTheSame(oldItem: PostWithUserInfo, newItem: PostWithUserInfo): Boolean {
+        return oldItem.post == newItem.post
     }
 
-    override fun areContentsTheSame(oldItem: Post, newItem: Post): Boolean {
+    override fun areContentsTheSame(oldItem: PostWithUserInfo, newItem: PostWithUserInfo): Boolean {
         return oldItem == newItem
     }
 }

--- a/app/src/main/java/com/survivalcoding/network_apps/feature_paging/presentation/adapter/PostInfoListAdapter.kt
+++ b/app/src/main/java/com/survivalcoding/network_apps/feature_paging/presentation/adapter/PostInfoListAdapter.kt
@@ -5,26 +5,18 @@ import androidx.paging.PagingDataAdapter
 import androidx.recyclerview.widget.ListAdapter
 import com.survivalcoding.network_apps.feature_paging.domain.model.Post
 import com.survivalcoding.network_apps.feature_paging.domain.model.User
+import com.survivalcoding.network_apps.feature_paging.presentation.PostWithUserInfo
 import kotlinx.coroutines.*
 
-class PostInfoListAdapter(
-    private val userFromCache: (id: Int) -> User?,
-    private val userFromNet: (id: Int) -> Unit
-) : PagingDataAdapter<Post, PostInfoViewHolder>(PostInfoDiffItemCallback) {
+class PostInfoListAdapter :
+    PagingDataAdapter<PostWithUserInfo, PostInfoViewHolder>(PostInfoDiffItemCallback) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PostInfoViewHolder =
         PostInfoViewHolder.builder(parent)
 
     override fun onBindViewHolder(holder: PostInfoViewHolder, position: Int) {
-        getItem(position)?.let { post ->
-            post.userId?.let { userId ->
-                val cacheData = userFromCache(userId)
-                if (cacheData == null) {
-                    userFromNet(userId)
-                }
-                println("in adapter=>"+userFromCache(userId))
-                holder.bind(post, cacheData)
-            }
+        getItem(position)?.let { item ->
+            holder.bind(item)
         }
     }
 }

--- a/app/src/main/java/com/survivalcoding/network_apps/feature_paging/presentation/adapter/PostInfoViewHolder.kt
+++ b/app/src/main/java/com/survivalcoding/network_apps/feature_paging/presentation/adapter/PostInfoViewHolder.kt
@@ -6,22 +6,22 @@ import androidx.recyclerview.widget.RecyclerView
 import com.survivalcoding.network_apps.databinding.ItemPostBinding
 import com.survivalcoding.network_apps.feature_paging.domain.model.Post
 import com.survivalcoding.network_apps.feature_paging.domain.model.User
+import com.survivalcoding.network_apps.feature_paging.presentation.PostWithUserInfo
 
 class PostInfoViewHolder(private val binding: ItemPostBinding) :
     RecyclerView.ViewHolder(binding.root) {
 
     private val CUSTOM_MAX_LINE = 50
 
-    fun bind(item: Post, userInfo: User? = null) {
-        binding.postName.text = item.title
-        binding.postContent.text = item.body
+    fun bind(item: PostWithUserInfo) {
+        binding.postName.text = item.post.title
+        binding.postContent.text = item.post.body
         binding.postContent.setOnClickListener {
             binding.postContent.maxLines =
                 if (binding.postContent.maxLines == 1) CUSTOM_MAX_LINE else 1
         }
-
-        userInfo?.let {
-            binding.postOwner.text = it.username
+        item.user?.username?.let {
+            binding.postOwner.text = it
         }
     }
 


### PR DESCRIPTION
기존 코드가 shy의 도움으로 user데이터가 왔을 때 업데이트가 되었지만 새로고침 될때마다 화면이 깜빡이고
상단으로 자동 이동된다는 점이 있어서 아예 새로 로직을 구성했습니다.

viewmodel 단에서 user정보의 유무를 판단한 결과를 PagingData<Post>.map{} 을 이용하여 
 PagingData(PostWithUserInfo)가 되게 했습니다. (PagingData 속 개별 post에 자유롭게 접근하고 싶었지만 map말고는 방법을 못찾았습니다.)
user정보 판단은 기존 코드와 유사하게 cache를 확인하고 없으면 network에 요청합니다. 

그래서  fragment나 adapter는 최대한 코드가 간단할 수 있도록 했습니다.

 shy의 코드처럼 datasource안에서 확인하는 방법이 현재 상황에서는 좋은 방법인 것 같습니다.
저는 완전 분리하고 싶은 생각에 시도했지만, 좋은 로직인지는 모르겠습니다.